### PR TITLE
removing oh my zsh as i moved to starship

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -22,6 +22,34 @@ if ! command -v starship >/dev/null 2>&1; then
 
   eval "$(starship init zsh)"
 
+# Keep a usable history and completions even without oh-my-zsh
+bindkey -e
+HISTFILE="$HOME/.zsh_history"
+HISTSIZE=50000
+SAVEHIST=50000
+setopt inc_append_history share_history hist_ignore_all_dups hist_find_no_dups extended_glob
+
+autoload -Uz compinit
+ZCOMPDUMP=${ZDOTDIR:-$HOME}/.zcompdump
+if [[ -n ${ZCOMPDUMP}(#qN.mh-24) ]]; then
+  compinit -C
+else
+  compinit
+fi
+
+# Prefix-search on arrow keys like the old history-substring-search plugin
+bindkey '^[[A' history-beginning-search-backward
+bindkey '^[[B' history-beginning-search-forward
+
+# Autosuggestions from history (Homebrew or manual install)
+if [ -f /opt/homebrew/share/zsh-autosuggestions/zsh-autosuggestions.zsh ]; then
+  source /opt/homebrew/share/zsh-autosuggestions/zsh-autosuggestions.zsh
+elif [ -f /usr/local/share/zsh-autosuggestions/zsh-autosuggestions.zsh ]; then
+  source /usr/local/share/zsh-autosuggestions/zsh-autosuggestions.zsh
+elif [ -f "$HOME/.zsh/zsh-autosuggestions/zsh-autosuggestions.zsh" ]; then
+  source "$HOME/.zsh/zsh-autosuggestions/zsh-autosuggestions.zsh"
+fi
+
 # User configuration and aliases
 
 source ~/.aliases

--- a/.zshrc
+++ b/.zshrc
@@ -42,12 +42,23 @@ bindkey '^[[A' history-beginning-search-backward
 bindkey '^[[B' history-beginning-search-forward
 
 # Autosuggestions from history (Homebrew or manual install)
+ZSH_AUTOSUGGEST_DIR="$HOME/.zsh/zsh-autosuggestions"
+ZSH_AUTOSUGGEST_FILE="$ZSH_AUTOSUGGEST_DIR/zsh-autosuggestions.zsh"
+if [ ! -f /opt/homebrew/share/zsh-autosuggestions/zsh-autosuggestions.zsh ] \
+  && [ ! -f /usr/local/share/zsh-autosuggestions/zsh-autosuggestions.zsh ] \
+  && [ ! -f "$ZSH_AUTOSUGGEST_FILE" ]; then
+  if command -v git >/dev/null 2>&1; then
+    mkdir -p "$HOME/.zsh"
+    GIT_TERMINAL_PROMPT=0 git clone https://github.com/zsh-users/zsh-autosuggestions "$ZSH_AUTOSUGGEST_DIR" >/dev/null 2>&1
+  fi
+fi
+
 if [ -f /opt/homebrew/share/zsh-autosuggestions/zsh-autosuggestions.zsh ]; then
   source /opt/homebrew/share/zsh-autosuggestions/zsh-autosuggestions.zsh
 elif [ -f /usr/local/share/zsh-autosuggestions/zsh-autosuggestions.zsh ]; then
   source /usr/local/share/zsh-autosuggestions/zsh-autosuggestions.zsh
-elif [ -f "$HOME/.zsh/zsh-autosuggestions/zsh-autosuggestions.zsh" ]; then
-  source "$HOME/.zsh/zsh-autosuggestions/zsh-autosuggestions.zsh"
+elif [ -f "$ZSH_AUTOSUGGEST_FILE" ]; then
+  source "$ZSH_AUTOSUGGEST_FILE"
 fi
 
 # User configuration and aliases

--- a/.zshrc
+++ b/.zshrc
@@ -63,7 +63,7 @@ fi
 
 # User configuration and aliases
 
-source ~/.aliases
+source ~/.aliases || true
 source ~/.aliases-local || true
 
 # custom functions

--- a/.zshrc
+++ b/.zshrc
@@ -9,9 +9,6 @@ export GOPATH=$HOME/go
 export PATH=$PATH:$GOROOT/bin:$GOPATH/bin
 export PATH=$PATH:$(go env GOPATH)/bin
 
-# Path to your oh-my-zsh installation.
-export ZSH=$HOME/.oh-my-zsh
-
 # Starship optional installation + sourcing
 if ! command -v starship >/dev/null 2>&1; then
     STARSHIP_HOME="${HOME}/.local/bin"
@@ -25,100 +22,7 @@ if ! command -v starship >/dev/null 2>&1; then
 
   eval "$(starship init zsh)"
 
-# Set list of themes to pick from when loading at random
-# Setting this variable when ZSH_THEME=random will cause zsh to load
-# a theme from this variable instead of looking in $ZSH/themes/
-# If set to an empty array, this variable will have no effect.
-# ZSH_THEME_RANDOM_CANDIDATES=( "robbyrussell" "agnoster" )
-
-# Uncomment the following line to use case-sensitive completion.
-# CASE_SENSITIVE="true"
-
-# Uncomment the following line to use hyphen-insensitive completion.
-# Case-sensitive completion must be off. _ and - will be interchangeable.
-# HYPHEN_INSENSITIVE="true"
-
-# Uncomment one of the following lines to change the auto-update behavior
-# zstyle ':omz:update' mode disabled  # disable automatic updates
-# zstyle ':omz:update' mode auto      # update automatically without asking
-# zstyle ':omz:update' mode reminder  # just remind me to update when it's time
-
-# Uncomment the following line to change how often to auto-update (in days).
-# zstyle ':omz:update' frequency 13
-
-# Uncomment the following line if pasting URLs and other text is messed up.
-# DISABLE_MAGIC_FUNCTIONS="true"
-
-# Uncomment the following line to disable colors in ls.
-# DISABLE_LS_COLORS="true"
-
-# Uncomment the following line to disable auto-setting terminal title.
-# DISABLE_AUTO_TITLE="true"
-
-# Uncomment the following line to enable command auto-correction.
-# ENABLE_CORRECTION="true"
-
-# Uncomment the following line to display red dots whilst waiting for completion.
-# You can also set it to another string to have that shown instead of the default red dots.
-# e.g. COMPLETION_WAITING_DOTS="%F{yellow}waiting...%f"
-# Caution: this setting can cause issues with multiline prompts in zsh < 5.7.1 (see #5765)
-# COMPLETION_WAITING_DOTS="true"
-
-# Uncomment the following line if you want to disable marking untracked files
-# under VCS as dirty. This makes repository status check for large repositories
-# much, much faster.
-# DISABLE_UNTRACKED_FILES_DIRTY="true"
-
-# Uncomment the following line if you want to change the command execution time
-# stamp shown in the history command output.
-# You can set one of the optional three formats:
-# "mm/dd/yyyy"|"dd.mm.yyyy"|"yyyy-mm-dd"
-# or set a custom format using the strftime function format specifications,
-# see 'man strftime' for details.
-# HIST_STAMPS="mm/dd/yyyy"
-
-# Would you like to use another custom folder than $ZSH/custom?
-# ZSH_CUSTOM=/path/to/new-custom-folder
-
-# Which plugins would you like to load?
-# Standard plugins can be found in $ZSH/plugins/
-# Custom plugins may be added to $ZSH_CUSTOM/plugins/
-# Example format: plugins=(rails git textmate ruby lighthouse)
-# Add wisely, as too many plugins slow down shell startup.
-plugins=(
-    git
-    zsh-autosuggestions
-
-)
-
-source $ZSH/oh-my-zsh.sh
-
-# User configuration
-
-# export MANPATH="/usr/local/man:$MANPATH"
-
-# You may need to manually set your language environment
-# export LANG=en_US.UTF-8
-
-# Preferred editor for local and remote sessions
-# if [[ -n $SSH_CONNECTION ]]; then
-#   export EDITOR='vim'
-# else
-#   export EDITOR='mvim'
-# fi
-
-# Compilation flags
-# export ARCHFLAGS="-arch x86_64"
-
-# Set personal aliases, overriding those provided by oh-my-zsh libs,
-# plugins, and themes. Aliases can be placed here, though oh-my-zsh
-# users are encouraged to define aliases within the ZSH_CUSTOM folder.
-# For a full list of active aliases, run `alias`.
-#
-# Example aliases
-# alias zshconfig="mate ~/.zshrc"
-# alias ohmyzsh="mate ~/.oh-my-zsh"
-#
+# User configuration and aliases
 
 source ~/.aliases
 source ~/.aliases-local || true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chore**
  * Removed the oh-my-zsh framework in favor of a lean, self-contained shell setup while retaining Starship initialization and common environment integrations to reduce startup complexity.
* **New Features**
  * Improved history handling, deterministic completions with conditional rebuilds, arrow-key prefix history search, cross-install autosuggestions (auto-clone/sourcing), tolerant alias sourcing, and new helper shell commands for Git and workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->